### PR TITLE
Update Makefile to build using z88dk 2.3.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,8 @@ Z88DK_CRT = 1
 DEBUGFLAGS =
 
 CC=zcc
-CCFLAGS=+zxn -vn -O3 -startup=$(Z88DK_CRT) -clib=new -preserve -pragma-include:zpragma.inc
-CZFLAGS=-Cz="--clean --fullsize --main-fence 0xC000"
+CCFLAGS=+zxn -vn -O3 -startup=$(Z88DK_CRT) -clib=new -pragma-include:zpragma.inc
+CZFLAGS=-Cz="--fullsize --main-fence 0xC000"
 LDFLAGS=-m -lm
 INCFLAGS=
 


### PR DESCRIPTION
This makes a couple of small changes to the Makefile to allow QE to be built using z88dk 2.3.
Fixes #1